### PR TITLE
Update query to check for sensors with type that starts with "EXIT" instead equal to "EXIT" to reflect the different types of EXIT.

### DIFF
--- a/custom_module/cypher_queries/custom_query_library.py
+++ b/custom_module/cypher_queries/custom_query_library.py
@@ -181,7 +181,7 @@ class CustomCypherQueryLibrary:
             MATCH (f:Event) - [:OCCURRED_AT] -> (:Station {sysId: '$stationId'})
             MATCH  (f) - [:ACTS_ON] -> (:Entity:$exit_entity_label) - [:IS_OF_TYPE] -> (
             et:EntityType) <- [:OUTPUT] - (composition:CompositionOperation)
-            MATCH (f) - [:EXECUTED_BY] -> (sensor:Sensor {type: "EXIT"})
+            MATCH (f) - [:EXECUTED_BY] -> (sensor:Sensor WHERE sensor.type STARTS WITH "EXIT")
             WHERE NOT EXISTS ((:Event) - [:DF_CONTROL_FLOW_ITEM] -> (f))
             SET f.tempNumRange =  range(f.tempNumberInRun*composition.inputQuantity, 
             (f.tempNumberInRun+1)*composition.inputQuantity-1)


### PR DESCRIPTION
See title