### PR TITLE
Change topology schema

### DIFF
--- a/custom_module/cypher_queries/custom_query_library.py
+++ b/custom_module/cypher_queries/custom_query_library.py
@@ -382,7 +382,7 @@ class CustomCypherQueryLibrary:
             MATCH (s1:Station) <- [:OCCURS_AT] - (:Activity) 
                 - [df] -> (:Activity) - [:OCCURS_AT] -> (s2:Station)
             WHERE s1 <> s2
-            MERGE (s1) - [:CONN {movedEntity: df.entityType}] -> (s2)
+            MERGE (s1) - [:ORIGIN] -> (:Entity:Resource:Connection) - [:DESTINATION] -> (s2)
         '''
 
         return Query(query_str=query_str)
@@ -395,7 +395,7 @@ class CustomCypherQueryLibrary:
             [:EXECUTED_BY] -> (s2:Sensor) 
             WHERE s1 <> s2
             WITH DISTINCT s1, s2, df.entityType as movedEntity
-            MERGE (s1) - [:CONN {movedEntity: movedEntity}] -> (s2)
+            MERGE (s1) - [:ORIGIN] -> (:Entity:Resource:Connection {movedEntity: movedEntity}) - [:DESTINATION] -> (s2)
             '''
 
         return Query(query_str=query_str)

--- a/json_files/ToyExample.json
+++ b/json_files/ToyExample.json
@@ -2,6 +2,7 @@
   "name": "ToyExample",
   "version": "3.6.1",
   "records": [
+    "(record:Record {log})",
     "(record:EventRecord:SensorEventRecord {timestamp, sensorId})",
     "(record:EntityRecord:PizzaRecord {pizzaId})",
     "(record:EntityRecord:PackRecord {packId})",
@@ -183,7 +184,7 @@
       "constructor": [
         {
           "prevalent_record": "(record:StationRecord)",
-          "result": "(v:Entity:Resource:Station:Location {sysId: record.stationName, OPTIONAL type: record.stationType})",
+          "result": "(v:Entity:Resource:Station {sysId: record.stationName, OPTIONAL type: record.stationType})",
           "infer_corr_from_event_record": true,
           "corr_type": "OCCURRED_AT"
         }

--- a/json_files/ToyExample_DS.json
+++ b/json_files/ToyExample_DS.json
@@ -19,6 +19,7 @@
       "SensorRecord",
       "EntityTypeRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -76,6 +77,7 @@
       "PizzaQualityAttributeRecord",
       "EntityTypeRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -145,6 +147,7 @@
       "SensorRecord",
       "EntityTypeRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -203,6 +206,7 @@
       "SensorRecord",
       "EntityTypeRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -264,6 +268,7 @@
       "SensorRecord",
       "EntityTypeRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -319,6 +324,7 @@
       "StationRecord",
       "AssemblyLineRecord"
     ],
+    "add_log": true,
     "attributes": [
       {
         "name": "sensorId",
@@ -382,6 +388,7 @@
       "CompositionRecord",
       "StationRecord"
     ],
+    "add_log": true,
     "attributes": [
       {
         "name": "code",
@@ -497,6 +504,7 @@
       "OperatorRecord",
       "OperatorEventRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -544,6 +552,7 @@
       "StatusEventRecord",
       "LockStatusRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {
@@ -590,6 +599,7 @@
       "WIPEventRecord",
       "SensorRecord"
     ],
+    "add_log": true,
     "seperator": ";",
     "attributes": [
       {


### PR DESCRIPTION
- Relabel each “:Entity:Resource:Station:Location” node to “:Entity:Resource:Station”
- Replace each “:CONN” relationship by a “:Entity:Resource:Connection” node that has “:ORIGIN” and “:DESTINATION” relationships with the original and the destination “:Entity:Resource:Station” nodes